### PR TITLE
Use rustfmt standard Rust syntax

### DIFF
--- a/src/_radeco.rs
+++ b/src/_radeco.rs
@@ -7,73 +7,81 @@ use self::r2pipe::R2Pipe;
 use self::radeco_lib::frontend::r2::R2;
 
 pub struct Radeco {
-	filename: String,
-	r2p: Option<R2Pipe>,
-	r2p2: Option<R2>,
+    filename: String,
+    r2p: Option<R2Pipe>,
+    r2p2: Option<R2>,
 }
 
 pub fn spawn_shell(bname: String) -> i32 {
-	let mut r2 = R2::new(&*bname);
-	loop {
-		let mut input = String::new();
-		print!("r2>> ");
-		io::stdout().flush().ok();
-		io::stdin().read_line(&mut input).ok();
-		let input = input.trim();
-		if input.len() == 0 || input == "exit" {
-			r2.send("quit");
-			break;
-		}
-		r2.send(&*input);
-		print!("{}", r2.recv());
-	}
-	0
+    let mut r2 = R2::new(&*bname);
+    loop {
+        let mut input = String::new();
+        print!("r2>> ");
+        io::stdout().flush().ok();
+        io::stdin().read_line(&mut input).ok();
+        let input = input.trim();
+        if input.len() == 0 || input == "exit" {
+            r2.send("quit");
+            break;
+        }
+        r2.send(&*input);
+        print!("{}", r2.recv());
+    }
+    0
 }
 
 impl Radeco {
-	/* TODO: use readline, dietline or any other rust-friendly prompt library */
-	pub fn shell(&mut self) -> bool {
-		println!("shellify {:?}", self.filename);
-		let mut stdin = io::stdin();
-		'mainloop: loop {
-			let mut input = String::new();
-			print!("> ");
-			io::stdout().flush().ok();
-			stdin.read_line(&mut input).ok();
+    // TODO: use readline, dietline or any other rust-friendly prompt library
+    pub fn shell(&mut self) -> bool {
+        println!("shellify {:?}", self.filename);
+        let mut stdin = io::stdin();
+        'mainloop: loop {
+            let mut input = String::new();
+            print!("> ");
+            io::stdout().flush().ok();
+            stdin.read_line(&mut input).ok();
 
-			if input == "" || input == "exit\n" {
-				break 'mainloop;
-			}
+            if input == "" || input == "exit\n" {
+                break 'mainloop;
+            }
 
-			match self.r2p.as_mut() {
-				Some(p) => println!("{}", p.cmd(input.trim())),
-				None => println!("No r2p")
-			}
-		}
-		true
-	}
+            match self.r2p.as_mut() {
+                Some(p) => println!("{}", p.cmd(input.trim())),
+                None => println!("No r2p"),
+            }
+        }
+        true
+    }
 
-	pub fn close(&mut self) -> bool {
-		match self.r2p.as_mut() {
-			Some(p) => p.close(),
-			None => println!("")
-		}
-		true
-	}
+    pub fn close(&mut self) -> bool {
+        match self.r2p.as_mut() {
+            Some(p) => p.close(),
+            None => println!(""),
+        }
+        true
+    }
 
-	pub fn file(filename: String) -> Result<Radeco, &'static str> {
-		let mut r = Radeco{filename: filename.to_owned(), r2p: None, r2p2: None};
-		let r2p = R2Pipe::spawn(&*filename).unwrap();
-		r.r2p = Some(r2p);
-		// Err("[r2pipe] initialization error")
-		Ok(r)
-	}
+    pub fn file(filename: String) -> Result<Radeco, &'static str> {
+        let mut r = Radeco {
+            filename: filename.to_owned(),
+            r2p: None,
+            r2p2: None,
+        };
+        let r2p = R2Pipe::spawn(&*filename).unwrap();
+        r.r2p = Some(r2p);
+        // Err("[r2pipe] initialization error")
+        Ok(r)
+    }
 
-	pub fn pipe() -> Result<Radeco, &'static str> {
-		let mut r = Radeco{filename: "".to_owned(), r2p: None, r2p2: None};
-		let r2p = R2Pipe::open().unwrap();
-		r.r2p = Some(r2p);
-		// Err("[r2pipe] initialization error")
-		Ok(r)
-	}
+    pub fn pipe() -> Result<Radeco, &'static str> {
+        let mut r = Radeco {
+            filename: "".to_owned(),
+            r2p: None,
+            r2p2: None,
+        };
+        let r2p = R2Pipe::open().unwrap();
+        r.r2p = Some(r2p);
+        // Err("[r2pipe] initialization error")
+        Ok(r)
+    }
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,6 +1,6 @@
 //! Module that parses arguments and initializes radeco
 use errors::ArgError;
-use std::io::{Read};
+use std::io::Read;
 use std::process::Command;
 
 use docopt::Docopt;
@@ -11,40 +11,53 @@ static USAGE: &'static str = "
 radeco. The radare2 decompiler.
 Usage:
   radeco <file>
-  radeco [options] [<file>]
+  radeco \
+                              [options] [<file>]
   radeco run [options] [<file>]
 
 Options:
-  --config <json_file>     Run decompilation using json rules file.
-  --make-config <file>     Wizard to make the JSON config.
-  -a --address=<addr>      Address of function to decompile.
-  -e --esil=<esil_expr>    Evaluate given esil expression.
-  -o --output=<output>     Specify output directory.
-  -p --pipeline=<pipe>     Stages in the pipeline. Comma separated values.
-                           Prefix the string with '=' (such as =ssa)
+  \
+                              --config <json_file>     Run decompilation using json rules file.
+  \
+                              --make-config <file>     Wizard to make the JSON config.
+  -a \
+                              --address=<addr>      Address of function to decompile.
+  -e \
+                              --esil=<esil_expr>    Evaluate given esil expression.
+  -o \
+                              --output=<output>     Specify output directory.
+  -p \
+                              --pipeline=<pipe>     Stages in the pipeline. Comma separated \
+                              values.
+                           Prefix the string with '=' (such \
+                              as =ssa)
                            to obtain the output the stage.
-                           Valid values: c,r2,ssa,cfg,const,dce,verify,svg,png
-  -q --quiet               Display silent output.
-  -s --shell               Run interactive prompt.
+                           \
+                              Valid values: c,r2,ssa,cfg,const,dce,verify,svg,png
+  -q --quiet               \
+                              Display silent output.
+  -s --shell               Run interactive \
+                              prompt.
   -v --version             Show version.
-  -h --help                Show this screen.
+  -h --help                \
+                              Show this screen.
 ";
 
 #[derive(Debug, RustcDecodable)]
 struct Args {
-	arg_esil_expr:    Option<Vec<String>>,
-	arg_file:         Option<String>,
-	cmd_run:          bool,
-	flag_address:     Option<String>,
-	flag_config:      Option<String>,
-	flag_help:        bool,
-	flag_make_config: bool,
-	flag_shell:       bool,
-	flag_quiet:       bool,
-	flag_version:     bool,
-	flag_output:      Option<String>,
-	flag_esil:        Option<Vec<String>>,
-	flag_pipeline:    Option<String>,
+    arg_esil_expr: Option<Vec<String>>,
+    arg_file: Option<String>,
+    cmd_run: bool,
+    flag_address: Option<String>,
+    flag_config: Option<String>,
+    flag_help: bool,
+    flag_make_config: bool,
+    flag_shell: bool,
+    flag_quiet: bool,
+    flag_version: bool,
+    flag_output: Option<String>,
+    flag_esil: Option<Vec<String>>,
+    flag_pipeline: Option<String>,
 }
 
 const VERSION: &'static str = env!("CARGO_PKG_VERSION");
@@ -52,27 +65,27 @@ const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 pub type ArgResult<T> = Option<Result<T, ArgError>>;
 
 fn make_config() -> structs::Input {
-	structs::input_builder()
+    structs::input_builder()
 }
 
 #[allow(dead_code)]
 pub struct Radeco {
-	bin_name:    Option<String>,
-	esil:        Option<Vec<String>>,
-	addr:        String,
-	name:        Option<String>,
-	outpath:     String,
-	stages:      Vec<usize>,
-	quiet:       bool,
-	runner:      Option<radeco_lib::utils::Runner>,
-	outmodes:    Option<Vec<u16>>,
-	post_runner: Option<Vec<PostRunner>>,
+    bin_name: Option<String>,
+    esil: Option<Vec<String>>,
+    addr: String,
+    name: Option<String>,
+    outpath: String,
+    stages: Vec<usize>,
+    quiet: bool,
+    runner: Option<radeco_lib::utils::Runner>,
+    outmodes: Option<Vec<u16>>,
+    post_runner: Option<Vec<PostRunner>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum PostRunner {
-	Genpng,
-	Gensvg,
+    Genpng,
+    Gensvg,
 }
 
 macro_rules! radeco_out {
@@ -84,187 +97,183 @@ macro_rules! radeco_out {
 }
 
 impl Radeco {
-	pub fn new(input: structs::Input, post: Option<Vec<PostRunner>>) ->
-		                                                      ArgResult<Radeco>
-	{
-		let runner = input.validate();
-		if runner.is_err() {
-			return Some(Err(runner.err().unwrap()));
-		}
+    pub fn new(input: structs::Input, post: Option<Vec<PostRunner>>) -> ArgResult<Radeco> {
+        let runner = input.validate();
+        if runner.is_err() {
+            return Some(Err(runner.err().unwrap()));
+        }
 
-		let radeco = Radeco {
-			bin_name: input.bin_name.clone(),
-			esil: input.esil.clone(),
-			addr: input.addr.clone().unwrap(),
-			name: input.name.clone(),
-			outpath: input.outpath.clone().unwrap(),
-			stages: input.stages.clone(),
-			quiet: input.quiet.clone().unwrap(),
-			runner: runner.ok(),
-			outmodes: input.outmodes.clone(),
-			post_runner: post,
-		};
+        let radeco = Radeco {
+            bin_name: input.bin_name.clone(),
+            esil: input.esil.clone(),
+            addr: input.addr.clone().unwrap(),
+            name: input.name.clone(),
+            outpath: input.outpath.clone().unwrap(),
+            stages: input.stages.clone(),
+            quiet: input.quiet.clone().unwrap(),
+            runner: runner.ok(),
+            outmodes: input.outmodes.clone(),
+            post_runner: post,
+        };
 
-		Some(Ok(radeco))
-	}
+        Some(Ok(radeco))
+    }
 
-	pub fn init() -> ArgResult<Radeco> {
-		let args: Args = Docopt::new(USAGE)
-			.and_then(|d| d.decode())
-			.unwrap_or_else(|e| e.exit());
+    pub fn init() -> ArgResult<Radeco> {
+        let args: Args = Docopt::new(USAGE)
+                             .and_then(|d| d.decode())
+                             .unwrap_or_else(|e| e.exit());
 
-		if args.flag_version {
-			println!("Version: {:?}", VERSION);
-			return None;
-		} else if args.flag_help {
-			println!("{}", USAGE);
-			return None;
-		}
+        if args.flag_version {
+            println!("Version: {:?}", VERSION);
+            return None;
+        } else if args.flag_help {
+            println!("{}", USAGE);
+            return None;
+        }
 
-		let mut post_runner = Vec::<PostRunner>::new();
-		// Make config file and run radeco with it
-		if args.flag_make_config {
-			let input = make_config();
-			input.spew_json();
-			// TODO: populate post_runner
-			return Radeco::new(input, Some(post_runner));
-		}
+        let mut post_runner = Vec::<PostRunner>::new();
+        // Make config file and run radeco with it
+        if args.flag_make_config {
+            let input = make_config();
+            input.spew_json();
+            // TODO: populate post_runner
+            return Radeco::new(input, Some(post_runner));
+        }
 
-		// Run from a predefined configuration file
-		if args.flag_config.is_some() {
-			let filename = args.flag_config.clone().unwrap();
-			let input = structs::Input::from_config(filename);
-			if input.is_err() {
-				return Some(Err(input.err().unwrap()))
-			}
-			return Radeco::new(input.unwrap(), Some(post_runner));
-		}
+        // Run from a predefined configuration file
+        if args.flag_config.is_some() {
+            let filename = args.flag_config.clone().unwrap();
+            let input = structs::Input::from_config(filename);
+            if input.is_err() {
+                return Some(Err(input.err().unwrap()));
+            }
+            return Radeco::new(input.unwrap(), Some(post_runner));
+        }
 
-		let mut input = structs::Input::defaults();
+        let mut input = structs::Input::defaults();
 
-		if args.arg_file.is_some() {
-			input.bin_name = args.arg_file;
-		}
-		if args.flag_address.is_some() {
-			input.addr = args.flag_address;
-		}
-		if args.flag_esil.is_some() {
-			input.esil = args.flag_esil;
-		}
-		input.quiet = Some(!args.flag_quiet);
-		if args.flag_output.is_some() {
-			input.outpath = args.flag_output;
-		}
+        if args.arg_file.is_some() {
+            input.bin_name = args.arg_file;
+        }
+        if args.flag_address.is_some() {
+            input.addr = args.flag_address;
+        }
+        if args.flag_esil.is_some() {
+            input.esil = args.flag_esil;
+        }
+        input.quiet = Some(!args.flag_quiet);
+        if args.flag_output.is_some() {
+            input.outpath = args.flag_output;
+        }
 
-		if args.flag_pipeline.is_some() {
-			let pipe = args.flag_pipeline.unwrap();
-			let mut _tmp_stages = Vec::<usize>::new();
-			let mut exclude = Vec::<u16>::new();
-			for (i, stage) in pipe.split(',').enumerate() {
-				let j = match stage.chars().nth(0).unwrap() {
-					'-' => {
-						exclude.push(i as u16);
-						1
-					},
-					'+' => 1,
-					_   => 0,
-				};
+        if args.flag_pipeline.is_some() {
+            let pipe = args.flag_pipeline.unwrap();
+            let mut _tmp_stages = Vec::<usize>::new();
+            let mut exclude = Vec::<u16>::new();
+            for (i, stage) in pipe.split(',').enumerate() {
+                let j = match stage.chars().nth(0).unwrap() {
+                    '-' => {
+                        exclude.push(i as u16);
+                        1
+                    }
+                    '+' => 1,
+                    _ => 0,
+                };
 
-				// Try and match with post runner stages
-				match &stage[j..] {
-					"png" =>{
-						post_runner.push(PostRunner::Genpng);
-						continue;
-					},
-					"svg" => {
-						post_runner.push(PostRunner::Gensvg);
-						continue;
-					},
-					_ => (),
-				}
+                // Try and match with post runner stages
+                match &stage[j..] {
+                    "png" => {
+                        post_runner.push(PostRunner::Genpng);
+                        continue;
+                    }
+                    "svg" => {
+                        post_runner.push(PostRunner::Gensvg);
+                        continue;
+                    }
+                    _ => (),
+                }
 
-				let n = match &stage[j..] {
-					"r2"      => 0,
-					"esil"    => 1,
-					"cfg"     => 2,
-					"ssa"     => 3,
-					"const"   => 4,
-					"dce"     => 5,
-					"verify"  => 6,
-					"c"       => 7,
-					_ => {
-						let e =
-							ArgError::InvalidArgument(stage[j..].to_owned());
-						return Some(Err(e));
-					},
-				};
-				_tmp_stages.push(n);
-			}
+                let n = match &stage[j..] {
+                    "r2" => 0,
+                    "esil" => 1,
+                    "cfg" => 2,
+                    "ssa" => 3,
+                    "const" => 4,
+                    "dce" => 5,
+                    "verify" => 6,
+                    "c" => 7,
+                    _ => {
+                        let e = ArgError::InvalidArgument(stage[j..].to_owned());
+                        return Some(Err(e));
+                    }
+                };
+                _tmp_stages.push(n);
+            }
 
-			let mut _tmp_out = Vec::<u16>::new();
-			for i in (0..(pipe.len() - 1) as u16) {
-				if exclude.contains(&i) {
-					continue;
-				}
-				_tmp_out.push(i);
-			}
-			input.stages = _tmp_stages;
-			input.outmodes = Some(_tmp_out);
-		}
+            let mut _tmp_out = Vec::<u16>::new();
+            for i in (0..(pipe.len() - 1) as u16) {
+                if exclude.contains(&i) {
+                    continue;
+                }
+                _tmp_out.push(i);
+            }
+            input.stages = _tmp_stages;
+            input.outmodes = Some(_tmp_out);
+        }
 
-		Radeco::new(input, Some(post_runner))
-	}
+        Radeco::new(input, Some(post_runner))
+    }
 
-	pub fn run(&mut self) -> Result<(), String> {
-		match self.runner.as_mut() {
-			Some(ref mut runner) => {
-				radeco_out!("[*] Starting radeco with config: ",
-							                runner.is_verbose());
-				radeco_out!(runner, runner.is_verbose());
-				runner.run()
-			},
-			None => panic!("Uninitialized instance of radeco!"),
-		}
-		Ok(())
-	}
+    pub fn run(&mut self) -> Result<(), String> {
+        match self.runner.as_mut() {
+            Some(ref mut runner) => {
+                radeco_out!("[*] Starting radeco with config: ", runner.is_verbose());
+                radeco_out!(runner, runner.is_verbose());
+                runner.run()
+            }
+            None => panic!("Uninitialized instance of radeco!"),
+        }
+        Ok(())
+    }
 
-	pub fn output(&mut self) {
-		match self.runner.as_mut() {
-			Some(ref mut runner) => {
-				radeco_out!("[*] Writing output", runner.is_verbose());
-				runner.output(self.outmodes.clone());
-			},
-			None => panic!("Uninitialized instance of radeco!"),
-		}
+    pub fn output(&mut self) {
+        match self.runner.as_mut() {
+            Some(ref mut runner) => {
+                radeco_out!("[*] Writing output", runner.is_verbose());
+                runner.output(self.outmodes.clone());
+            }
+            None => panic!("Uninitialized instance of radeco!"),
+        }
 
-		// Post processing phases defined in radeco
-		// These can be generation of svg, png etc
-		for phase in self.post_runner.as_ref().unwrap() {
-			match *phase {
-				PostRunner::Genpng |
-				PostRunner::Gensvg => {
-					let format = if *phase == PostRunner::Genpng {
-						"png"
-					} else {
-						"svg"
-					};
-					radeco_out!("[*] Generating svg",
-								self.runner.as_ref().unwrap().is_verbose());
-					let mut cmd = String::new();
-					let mut target = self.outpath.clone();
-					target.push_str("/");
-					target.push_str(&self.name.as_ref().unwrap());
-					target.push_str("/*.dot");
-					cmd.push_str(&format!("dot -T{} -O ", format));
-					cmd.push_str(&target);
+        // Post processing phases defined in radeco
+        // These can be generation of svg, png etc
+        for phase in self.post_runner.as_ref().unwrap() {
+            match *phase {
+                PostRunner::Genpng |
+                PostRunner::Gensvg => {
+                    let format = if *phase == PostRunner::Genpng {
+                        "png"
+                    } else {
+                        "svg"
+                    };
+                    radeco_out!("[*] Generating svg",
+                                self.runner.as_ref().unwrap().is_verbose());
+                    let mut cmd = String::new();
+                    let mut target = self.outpath.clone();
+                    target.push_str("/");
+                    target.push_str(&self.name.as_ref().unwrap());
+                    target.push_str("/*.dot");
+                    cmd.push_str(&format!("dot -T{} -O ", format));
+                    cmd.push_str(&target);
 
-					let _ = Command::new("sh")
-						.arg("-c")
-						.arg(cmd)
-					    .output()
-						.unwrap();
-				},
-			}
-		}
-	}
+                    let _ = Command::new("sh")
+                                .arg("-c")
+                                .arg(cmd)
+                                .output()
+                                .unwrap();
+                }
+            }
+        }
+    }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,37 +4,39 @@ use rustc_serialize::json;
 
 #[derive(Debug)]
 pub enum ArgError {
-	DecodeError(json::DecoderError),
-	InvalidArgument(String),
-	IoError(io::Error),
-	InvalidSource(String),
-	NoSource,
-	MultipleSources,
-	MissingArgument(String),
+    DecodeError(json::DecoderError),
+    InvalidArgument(String),
+    IoError(io::Error),
+    InvalidSource(String),
+    NoSource,
+    MultipleSources,
+    MissingArgument(String),
 }
 
 impl fmt::Display for ArgError {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		match *self {
-			ArgError::IoError(ref err) => write!(f, "{}", err),
-			ArgError::DecodeError(ref err) => write!(f, "{}", err),
-			ArgError::InvalidArgument(ref err) => write!(f, "Invalid Argument: {}", err),
-			ArgError::NoSource => write!(f, "{}", "No source to run on. Please input binary or raw esil"),
-			ArgError::MultipleSources => write!(f, "{}", "Cannot run radeco on multiple sources"),
-			ArgError::MissingArgument(ref err) => write!(f, "Missing Argument: {}", err),
-			ArgError::InvalidSource(ref err) => write!(f, "{}", err),
-		}
-	}
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            ArgError::IoError(ref err) => write!(f, "{}", err),
+            ArgError::DecodeError(ref err) => write!(f, "{}", err),
+            ArgError::InvalidArgument(ref err) => write!(f, "Invalid Argument: {}", err),
+            ArgError::NoSource => write!(f,
+                                         "{}",
+                                         "No source to run on. Please input binary or raw esil"),
+            ArgError::MultipleSources => write!(f, "{}", "Cannot run radeco on multiple sources"),
+            ArgError::MissingArgument(ref err) => write!(f, "Missing Argument: {}", err),
+            ArgError::InvalidSource(ref err) => write!(f, "{}", err),
+        }
+    }
 }
 
 impl From<io::Error> for ArgError {
-	fn from(e: io::Error) -> ArgError {
-		ArgError::IoError(e)
-	}
+    fn from(e: io::Error) -> ArgError {
+        ArgError::IoError(e)
+    }
 }
 
 impl From<json::DecoderError> for ArgError {
-	fn from(e: json::DecoderError) -> ArgError {
-		ArgError::DecodeError(e)
-	}
+    fn from(e: json::DecoderError) -> ArgError {
+        ArgError::DecodeError(e)
+    }
 }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -4,60 +4,60 @@ use log::{LogRecord, LogLevel, LogMetadata, LogLevelFilter, SetLoggerError};
 
 #[derive(Debug, RustcDecodable, RustcEncodable)]
 pub struct RadecoLog {
-	log: Vec<RadecoRecord>
+    log: Vec<RadecoRecord>,
 }
 
 #[derive(Debug, RustcDecodable, RustcEncodable)]
 pub struct RadecoRecord {
-	event: String,
-	kind: Kind,
-	args: Vec<String>,
-	file: String,
-	line: u32,
+    event: String,
+    kind: Kind,
+    args: Vec<String>,
+    file: String,
+    line: u32,
 }
 
 #[derive(Debug, RustcDecodable, RustcEncodable)]
 pub enum Kind {
-	SSA,
+    SSA,
 }
 
 impl RadecoRecord {
-	fn new(event: String, kind: Kind, args: Vec<String>, f: String,
-	       l: u32) -> RadecoRecord 
-	{
-		RadecoRecord {
-			event: event,
-			kind: kind,
-			args: args,
-			file: f,
-			line: l,
-		}
-	}
+    fn new(event: String, kind: Kind, args: Vec<String>, f: String, l: u32) -> RadecoRecord {
+        RadecoRecord {
+            event: event,
+            kind: kind,
+            args: args,
+            file: f,
+            line: l,
+        }
+    }
 }
 
 impl log::Log for RadecoLog {
-	fn enabled(&self, metadata: &LogMetadata) -> bool {
-		metadata.level() <= LogLevel::Trace
-	}
+    fn enabled(&self, metadata: &LogMetadata) -> bool {
+        metadata.level() <= LogLevel::Trace
+    }
 
-	fn log(&self, record: &LogRecord) {
-		if self.enabled(record.metadata()) {
-			println!("{} - {} - {}:{}", record.level(), record.args(), record.location().file(), record.location().line());
-		}
-	}
+    fn log(&self, record: &LogRecord) {
+        if self.enabled(record.metadata()) {
+            println!("{} - {} - {}:{}",
+                     record.level(),
+                     record.args(),
+                     record.location().file(),
+                     record.location().line());
+        }
+    }
 }
 
 impl RadecoLog {
-	pub fn new() -> RadecoLog {
-		RadecoLog {
-			log: Vec::new(),
-		}
-	}
+    pub fn new() -> RadecoLog {
+        RadecoLog { log: Vec::new() }
+    }
 
-	pub fn init() -> Result<(), SetLoggerError> {
-		log::set_logger(|max_log_level| {
-			max_log_level.set(LogLevelFilter::Trace);
-			Box::new(RadecoLog::new())
-		})
-	}
+    pub fn init() -> Result<(), SetLoggerError> {
+        log::set_logger(|max_log_level| {
+            max_log_level.set(LogLevelFilter::Trace);
+            Box::new(RadecoLog::new())
+        })
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,39 +10,40 @@ mod structs;
 mod errors;
 mod args;
 
-#[cfg(feature = "trace_log")] 
+#[cfg(feature = "trace_log")]
 mod logger;
 
 use std::process::exit;
 
-#[cfg(not(feature = "trace_log"))] 
-fn init_logger() { }
-#[cfg(feature = "trace_log")] 
+#[cfg(not(feature = "trace_log"))]
 fn init_logger() {
-	logger::RadecoLog::init().ok();
+}
+#[cfg(feature = "trace_log")]
+fn init_logger() {
+    logger::RadecoLog::init().ok();
 }
 
 fn main() {
-	init_logger();
-	let radeco = args::Radeco::init();
-	if radeco.is_none() {
-		exit(0);
-	}
-	let radeco = radeco.unwrap();
-	if radeco.is_err() {
-		println!("[X] {}", radeco.err().unwrap());
-		exit(2);
-	}
+    init_logger();
+    let radeco = args::Radeco::init();
+    if radeco.is_none() {
+        exit(0);
+    }
+    let radeco = radeco.unwrap();
+    if radeco.is_err() {
+        println!("[X] {}", radeco.err().unwrap());
+        exit(2);
+    }
 
-	let mut radeco = radeco.unwrap();
-	let result = radeco.run();
+    let mut radeco = radeco.unwrap();
+    let result = radeco.run();
 
-	match result {
-		Ok(_) => {
-			radeco.output();
-		},
-		Err(e) => {
-			println!("[X] Error: {}", e);
-		},
-	}
+    match result {
+        Ok(_) => {
+            radeco.output();
+        }
+        Err(e) => {
+            println!("[X] Error: {}", e);
+        }
+    }
 }

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -2,179 +2,184 @@
 
 use std::io;
 use std::fs;
-use std::path::{Path};
+use std::path::Path;
 use radeco_lib::utils::{Pipeline, Runner, Analysis, Pipeout};
 use radeco_lib::frontend::r2;
 use errors::ArgError;
-use std::fs::{File};
+use std::fs::File;
 use rustc_serialize::json;
 use std::io::{Read, Write};
 
 #[derive(RustcDecodable, RustcEncodable, Debug, Clone)]
 pub enum Outmode {
-	Pseudo,
-	Dot,
+    Pseudo,
+    Dot,
 }
-	
+
 #[derive(RustcDecodable, RustcEncodable, Debug, Clone)]
 pub struct Input {
-	pub bin_name: Option<String>,
-	pub esil: Option<Vec<String>>,
-	pub addr: Option<String>,
-	pub name: Option<String>,
-	pub outpath: Option<String>,
-	pub stages: Vec<usize>,
-	pub quiet: Option<bool>,
-	pub outmodes: Option<Vec<u16>>,
+    pub bin_name: Option<String>,
+    pub esil: Option<Vec<String>>,
+    pub addr: Option<String>,
+    pub name: Option<String>,
+    pub outpath: Option<String>,
+    pub stages: Vec<usize>,
+    pub quiet: Option<bool>,
+    pub outmodes: Option<Vec<u16>>,
 }
 
 fn write_file(fname: String, res: String) {
-	let mut file = File::create(fname).unwrap();
-	file.write_all(res.as_bytes()).unwrap();
+    let mut file = File::create(fname).unwrap();
+    file.write_all(res.as_bytes()).unwrap();
 }
 
 impl Input {
-	fn new(bin_name: Option<String>, esil: Option<Vec<String>>,
-		   addr: Option<String>, name: Option<String>,
-		   outpath: Option<String>, stages: Vec<usize>,
-		   outmodes: Option<Vec<u16>>, quiet: bool) -> Input
-	{
-		Input {
-			bin_name: bin_name,
-			esil: esil,
-			addr: addr,
-			name: name,
-			outpath: outpath,
-			stages: stages.clone(),
-			quiet: Some(quiet),
-			outmodes: outmodes,
-		}
-	}
+    fn new(bin_name: Option<String>,
+           esil: Option<Vec<String>>,
+           addr: Option<String>,
+           name: Option<String>,
+           outpath: Option<String>,
+           stages: Vec<usize>,
+           outmodes: Option<Vec<u16>>,
+           quiet: bool)
+           -> Input {
+        Input {
+            bin_name: bin_name,
+            esil: esil,
+            addr: addr,
+            name: name,
+            outpath: outpath,
+            stages: stages.clone(),
+            quiet: Some(quiet),
+            outmodes: outmodes,
+        }
+    }
 
-	pub fn from_config(fname: String) -> Result<Input, ArgError> {
-		let mut fh = try!(File::open(fname));
-		let mut raw_json = String::new();
-		try!(fh.read_to_string(&mut raw_json));
-		json::decode(&*raw_json).map_err(|x| ArgError::DecodeError(x))
-	}
+    pub fn from_config(fname: String) -> Result<Input, ArgError> {
+        let mut fh = try!(File::open(fname));
+        let mut raw_json = String::new();
+        try!(fh.read_to_string(&mut raw_json));
+        json::decode(&*raw_json).map_err(|x| ArgError::DecodeError(x))
+    }
 
-	pub fn spew_json(&self) {
-		let mut name = self.name.as_ref().unwrap().clone();
-		let json = json::as_pretty_json(&self);
-		let raw_json = format!("{}", json);
-		name.push_str(".json");
-		write_file(name, raw_json);
-	}
+    pub fn spew_json(&self) {
+        let mut name = self.name.as_ref().unwrap().clone();
+        let json = json::as_pretty_json(&self);
+        let raw_json = format!("{}", json);
+        name.push_str(".json");
+        write_file(name, raw_json);
+    }
 
-	// Setup the defaults for the arguments:
-	// This depends on the mode radeco is operating in i.e:
-	//     - r2pipe, when called from within radare2
-	//                    ( vs )
-	//     - standalone, when radeco spawns radare2
-	// 
-	// Below is the list of defaults that are set depending on the mode.
-	//     - bin_name: binary loaded in r2 vs None
-	//     - esil: None vs None
-	//     - addr: current address vs entry0
-	//     - name: bin_name vs None
-	//     - outpath: bin_name_out vs outputs
-	//     - stages: All vs All
-	//     - quiet : false vs false
-	pub fn defaults() -> Input {
-		let bin_name;
-		let addr;
-		let name;
-		let outpath;
-		let stages = (0..5).collect::<Vec<_>>();
-		let outmodes = (0..5).collect::<Vec<_>>();
+    // Setup the defaults for the arguments:
+    // This depends on the mode radeco is operating in i.e:
+    //     - r2pipe, when called from within radare2
+    //                    ( vs )
+    //     - standalone, when radeco spawns radare2
+    //
+    // Below is the list of defaults that are set depending on the mode.
+    //     - bin_name: binary loaded in r2 vs None
+    //     - esil: None vs None
+    //     - addr: current address vs entry0
+    //     - name: bin_name vs None
+    //     - outpath: bin_name_out vs outputs
+    //     - stages: All vs All
+    //     - quiet : false vs false
+    pub fn defaults() -> Input {
+        let bin_name;
+        let addr;
+        let name;
+        let outpath;
+        let stages = (0..5).collect::<Vec<_>>();
+        let outmodes = (0..5).collect::<Vec<_>>();
 
-		if r2::R2::in_session() {
-			let mut r2 = r2::R2::new(None).unwrap();
-			addr = {
-				r2.send("s");
-				r2.recv().trim().to_owned()
-			};
-			// TODO: Error Handling here.
-			let bin_info = r2.get_bin_info().unwrap();
-			let core = bin_info.core.unwrap();
-			let path = match core.file.as_ref() {
-				Some(ref f) => {
-					bin_name = Some(format!("{}", f));
-					Path::new(f.clone())
-				},
-				None => panic!("No file open in r2"),
-			};
-			let file = path.file_name()
-				.unwrap()
-				.to_str()
-				.map(|s| s.to_owned());
-			outpath = format!("./{}_out", file.as_ref().unwrap());
-			name = Some(format!("{}.run", file.as_ref().unwrap()));
-		} else {
-			bin_name = None;
-			addr = "entry0".to_owned();
-			name = None;
-			outpath = "./outputs".to_owned();
-		}
+        if r2::R2::in_session() {
+            let mut r2 = r2::R2::new(None).unwrap();
+            addr = {
+                r2.send("s");
+                r2.recv().trim().to_owned()
+            };
+            // TODO: Error Handling here.
+            let bin_info = r2.get_bin_info().unwrap();
+            let core = bin_info.core.unwrap();
+            let path = match core.file.as_ref() {
+                Some(ref f) => {
+                    bin_name = Some(format!("{}", f));
+                    Path::new(f.clone())
+                }
+                None => panic!("No file open in r2"),
+            };
+            let file = path.file_name()
+                           .unwrap()
+                           .to_str()
+                           .map(|s| s.to_owned());
+            outpath = format!("./{}_out", file.as_ref().unwrap());
+            name = Some(format!("{}.run", file.as_ref().unwrap()));
+        } else {
+            bin_name = None;
+            addr = "entry0".to_owned();
+            name = None;
+            outpath = "./outputs".to_owned();
+        }
 
-		Input {
-			bin_name: bin_name,
-			esil: None,
-			addr: Some(addr),
-			name: name,
-			outpath: Some(outpath),
-			stages: stages,
-			outmodes: Some(outmodes),
-			quiet: Some(false),
-		}
-	}
+        Input {
+            bin_name: bin_name,
+            esil: None,
+            addr: Some(addr),
+            name: name,
+            outpath: Some(outpath),
+            stages: stages,
+            outmodes: Some(outmodes),
+            quiet: Some(false),
+        }
+    }
 
-	pub fn validate(&self) -> Result<Runner, ArgError> {
-		if self.bin_name.is_none() && self.esil.is_none() {
-			return Err(ArgError::NoSource);
-		}
+    pub fn validate(&self) -> Result<Runner, ArgError> {
+        if self.bin_name.is_none() && self.esil.is_none() {
+            return Err(ArgError::NoSource);
+        }
 
-		let bin = if self.bin_name.is_some() {
-			let _n = &self.bin_name.clone().unwrap();
-			let metadata = fs::metadata(_n);
-			if metadata.is_err() {
-				return Err(ArgError::InvalidSource("File does not exist".to_owned()));
-			}
-			if !metadata.unwrap().is_file() {
-				return Err(ArgError::InvalidSource("File does not exist".to_owned()));
-			}
-			self.bin_name.clone()
-		} else {
-			None
-		};
+        let bin = if self.bin_name.is_some() {
+            let _n = &self.bin_name.clone().unwrap();
+            let metadata = fs::metadata(_n);
+            if metadata.is_err() {
+                return Err(ArgError::InvalidSource("File does not exist".to_owned()));
+            }
+            if !metadata.unwrap().is_file() {
+                return Err(ArgError::InvalidSource("File does not exist".to_owned()));
+            }
+            self.bin_name.clone()
+        } else {
+            None
+        };
 
-		let esil = if self.esil.is_some() {
-			if bin.is_some() {
-				return Err(ArgError::MultipleSources);
-			}
-			self.esil.clone()
-		} else {
-			None
-		};
+        let esil = if self.esil.is_some() {
+            if bin.is_some() {
+                return Err(ArgError::MultipleSources);
+            }
+            self.esil.clone()
+        } else {
+            None
+        };
 
-		let addr = if self.addr.is_some() {
-			if bin.is_none() {
-				return Err(ArgError::InvalidArgument("Address provided without source binary".to_owned()));
-			}
-			self.addr.clone()
-		} else {
-			if bin.is_some() {
-				return Err(ArgError::MissingArgument("Address".to_owned()));
-			}
-			None
-		};
+        let addr = if self.addr.is_some() {
+            if bin.is_none() {
+                return Err(ArgError::InvalidArgument("Address provided without source binary"
+                                                         .to_owned()));
+            }
+            self.addr.clone()
+        } else {
+            if bin.is_some() {
+                return Err(ArgError::MissingArgument("Address".to_owned()));
+            }
+            None
+        };
 
-		let name = self.name.clone().unwrap_or("radeco_out".to_owned());
+        let name = self.name.clone().unwrap_or("radeco_out".to_owned());
 
-		let outpath = self.outpath.clone().unwrap_or("./outputs".to_owned());
-		fs::create_dir_all(&outpath).ok().expect("Unable to create directory for output.");
+        let outpath = self.outpath.clone().unwrap_or("./outputs".to_owned());
+        fs::create_dir_all(&outpath).ok().expect("Unable to create directory for output.");
 
-		let possible = vec![
+        let possible = vec![
 			Pipeline::ReadFromR2,
 			Pipeline::ParseEsil,
 			Pipeline::CFG,
@@ -185,20 +190,20 @@ impl Input {
 			Pipeline::CWriter,
 		];
 
-		let pipeline = self.stages.iter().map(|s| possible[*s]).collect::<Vec<Pipeline>>();
-		let quiet = self.quiet.unwrap_or(false);
-		let mut runner = Runner::new(name, bin, addr, quiet, pipeline, Some(outpath));
-		// Handle the case where the input is raw esil.
-		if esil.is_some() {
-			let filepath = self.bin_name.clone();
-			let mut r2 = r2::R2::new(filepath).unwrap();
-			r2.init();
-			let r = r2.get_reg_info().ok();
-			runner.state.pipeout = Some(Pipeout::Esil(esil.unwrap()));
-			runner.state.reg_info = r;
-		}
-		Ok(runner)
-	}
+        let pipeline = self.stages.iter().map(|s| possible[*s]).collect::<Vec<Pipeline>>();
+        let quiet = self.quiet.unwrap_or(false);
+        let mut runner = Runner::new(name, bin, addr, quiet, pipeline, Some(outpath));
+        // Handle the case where the input is raw esil.
+        if esil.is_some() {
+            let filepath = self.bin_name.clone();
+            let mut r2 = r2::R2::new(filepath).unwrap();
+            r2.init();
+            let r = r2.get_reg_info().ok();
+            runner.state.pipeout = Some(Pipeout::Esil(esil.unwrap()));
+            runner.state.reg_info = r;
+        }
+        Ok(runner)
+    }
 }
 
 macro_rules! input_or_none {
@@ -223,68 +228,74 @@ macro_rules! read {
 }
 
 pub fn input_builder() -> Input {
-	println!("Radeco Input Builder.");
-	println!("Binary name (if esil, skip this): ");
-	let bin_name = read!();
-	println!("Raw esil (skip if binary name was specified): ");
-	let esil: Option<Vec<String>> = {
-		let mut _tmpv = Vec::new();
-		loop {
-			let _esil = read!();
-			if _esil.is_none() {
-				break;
-			}
-			_tmpv.push(_esil.unwrap());
-		}
-		if _tmpv.is_empty() {
-			None
-		} else {
-			Some(_tmpv)
-		}
-	};
-	println!("Address to read instruction from (skip if raw esil): ");
-	let addr = read!();
-	println!("Name of this run: ");
-	let name = read!();
-	println!("Output directory: ");
-	let out_dir = read!();
+    println!("Radeco Input Builder.");
+    println!("Binary name (if esil, skip this): ");
+    let bin_name = read!();
+    println!("Raw esil (skip if binary name was specified): ");
+    let esil: Option<Vec<String>> = {
+        let mut _tmpv = Vec::new();
+        loop {
+            let _esil = read!();
+            if _esil.is_none() {
+                break;
+            }
+            _tmpv.push(_esil.unwrap());
+        }
+        if _tmpv.is_empty() {
+            None
+        } else {
+            Some(_tmpv)
+        }
+    };
+    println!("Address to read instruction from (skip if raw esil): ");
+    let addr = read!();
+    println!("Name of this run: ");
+    let name = read!();
+    println!("Output directory: ");
+    let out_dir = read!();
 
-	let mut pipe = Vec::<usize>::new();
-	loop {
-		println!("Stages in pipeline\n{}{}{}{}{}{}{}{}",
-				 "0. R2\n",
-				 "1. Parse Esil\n",
-				 "2. Build CFG\n",
-				 "3. Build SSA\n",
-				 "4. Constant Propagation\n",
-				 "5. Dead Code Elemination\n",
-				 "6. Verify\n",
-				 "(Enter comma separated choices):");
+    let mut pipe = Vec::<usize>::new();
+    loop {
+        println!("Stages in pipeline\n{}{}{}{}{}{}{}{}",
+                 "0. R2\n",
+                 "1. Parse Esil\n",
+                 "2. Build CFG\n",
+                 "3. Build SSA\n",
+                 "4. Constant Propagation\n",
+                 "5. Dead Code Elemination\n",
+                 "6. Verify\n",
+                 "(Enter comma separated choices):");
 
-		let _pipe = read!();
-		if _pipe.is_some() {
-			for i in _pipe.unwrap().split(",") {
-				let j: usize = i.parse::<usize>().unwrap();
-				pipe.push(j);
-			}
-		}
+        let _pipe = read!();
+        if _pipe.is_some() {
+            for i in _pipe.unwrap().split(",") {
+                let j: usize = i.parse::<usize>().unwrap();
+                pipe.push(j);
+            }
+        }
 
-		if !pipe.is_empty() { break; }
-		println!("Pipeline cannot be empty!");
-	}
+        if !pipe.is_empty() {
+            break;
+        }
+        println!("Pipeline cannot be empty!");
+    }
 
-	// TODO: honor Args.flag_verbose
-	let verbose = {
-		println!("Quiet (y/N):");
-		let _v = read!();
-		_v.or(Some("n".to_owned())).map(|c| match &*c {
-			"y" => true,
-			"n" => false,
-			_   => false,
-		}).unwrap()
-	};
+    // TODO: honor Args.flag_verbose
+    let verbose = {
+        println!("Quiet (y/N):");
+        let _v = read!();
+        _v.or(Some("n".to_owned()))
+          .map(|c| {
+              match &*c {
+                  "y" => true,
+                  "n" => false,
+                  _ => false,
+              }
+          })
+          .unwrap()
+    };
 
-	let outmodes = Some((0..(pipe.len() - 1) as u16).collect::<Vec<_>>());
+    let outmodes = Some((0..(pipe.len() - 1) as u16).collect::<Vec<_>>());
 
-	Input::new(bin_name, esil, addr, name, out_dir, pipe, outmodes, verbose)
+    Input::new(bin_name, esil, addr, name, out_dir, pipe, outmodes, verbose)
 }


### PR DESCRIPTION
@sushant94 now that rustfmt works with stable rust 1.3, seems like a reasonable change to stick to the Rust defaults. Even if I prefer tabs, having a standard tool for indenting code give us much more benefits than having a handy editor.